### PR TITLE
Add some to wordcloud arguments that generate better response in large scale.

### DIFF
--- a/src/image_to_wordcloud.py
+++ b/src/image_to_wordcloud.py
@@ -56,7 +56,8 @@ class ImageToWordcloud:
         text: str,
         output_dir: Union[str, Path],
         mask_image_path: Union[str, Path] = None,
-        width: int = 800, height: int = 600,
+        width: int = 600, height: int = 400,
+        scale: float = 1.0,
         max_font_size: int = 250,
         background_color: str = 'white',
     ):


### PR DESCRIPTION
using **scale** argument is better instead of manipulating **width** and **height** arguments in large scale situation.

[refrence link](https://www.datacamp.com/community/tutorials/wordcloud-python#:~:text=Notes%0A%2D%2D%2D%2D%2D%0ALarger%20canvases%20will%20make%20the%20code%20significantly%20slower.%20If%20you%20need%20a%0Alarge%20word%20cloud%2C%20try%20a%20lower%20canvas%20size%2C%20and%20set%20the%20scale%20parameter.) 